### PR TITLE
Rename in line with pointfree convention

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 let package = Package(
-  name: "ComposableUserNotifications",
+  name: "composable-user-notifications",
   platforms: [
     .iOS(.v13),
     .macOS(.v10_15),


### PR DESCRIPTION
Rename the package and the repository in line with `pointfree` conventions for composable family of modules.

Bonus suggestion, tag an 0.1.0 release after?