### PR TITLE
Enable setNotificationCategories for watchOS

### DIFF
--- a/Sources/ComposableUserNotifications/Live.swift
+++ b/Sources/ComposableUserNotifications/Live.swift
@@ -96,7 +96,7 @@ extension UserNotificationClient {
       }
     }
 
-    #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
+    #if os(iOS) || os(macOS) || os(watchOS)  || targetEnvironment(macCatalyst)
     client.setNotificationCategories = { categories in
       .fireAndForget {
         center.setNotificationCategories(categories)


### PR DESCRIPTION
Documentation says it should be available with watchOS 3+
https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/1649512-setnotificationcategories

I have a feeling a few of the others could also be enabled.